### PR TITLE
delete the previous added build option

### DIFF
--- a/lib/ceedling/test_invoker.rb
+++ b/lib/ceedling/test_invoker.rb
@@ -47,9 +47,13 @@ class TestInvoker
         results_pass = @file_path_utils.form_pass_results_filepath( test )
         results_fail = @file_path_utils.form_fail_results_filepath( test )
         
-		# add the definition value in the build option for the unit test
-		TOOLS_TEST_COMPILER[:arguments].push("-D#{File.basename(test, ".*").strip.upcase}")
-		puts("add the definition value in the build option for the unit test: #{TOOLS_TEST_COMPILER[:arguments][-1]}")
+        # add the definition value in the build option for the unit test
+        while TOOLS_TEST_COMPILER[:arguments][-1] =~ /^\-DTEST_[A-Z0-9_\-]+$/
+            puts("delete the previous added build option: #{TOOLS_TEST_COMPILER[:arguments][-1]}")
+            TOOLS_TEST_COMPILER[:arguments].delete_at(-1)
+        end
+        TOOLS_TEST_COMPILER[:arguments].push("-D#{File.basename(test, ".*").strip.upcase}")
+        puts("add the definition value in the build option for the unit test: #{TOOLS_TEST_COMPILER[:arguments][-1]}")
 
         # clean results files so we have a missing file with which to kick off rake's dependency rules
         @test_invoker_helper.clean_results( {:pass => results_pass, :fail => results_fail}, options )


### PR DESCRIPTION
Dear TE-HiroakiYamazoe

The build option seems to be keeping.
Delete the previous added the build option in the next unit test.
