### PR TITLE
Test definition

### DIFF
--- a/lib/ceedling/test_invoker.rb
+++ b/lib/ceedling/test_invoker.rb
@@ -54,7 +54,7 @@ class TestInvoker
                 puts("delete the previous added build option: #{tools_compiler_value[:arguments][-1]} #{tools_compiler_key}")
                 tools_compiler_value[:arguments].delete_at(-1)
             end
-            tools_compiler_value[:arguments].push("-D#{File.basename(test, ".*").strip.upcase}")
+            tools_compiler_value[:arguments].push("-D#{File.basename(test, ".*").strip.upcase.sub(/@.*$/, "")}")
             puts("add the definition value in the build option for the unit test: #{tools_compiler_value[:arguments][-1]} #{tools_compiler_key}")
         end
 


### PR DESCRIPTION
現在テストコードのファイル名から単体テスト用のdefine値を生成していますが、より汎用性を持たせるため、昨日の議論であったアイデアを実装してみました。
これによりアットマーク以降であれば任意の文字列を指定できるようになります。
例：
test_pli_PLI_SearchPli.c ← PLI_SearchPli（）の単体テスト0(今まで通り)
test_pli_PLI_SearchPli@Case1.c ← PLI_SearchPli（）の単体テスト1
test_pli_PLI_SearchPli@Case2.c ← PLI_SearchPli（）の単体テスト2

よろしくお願いします。
※とりあえず区切り文字としてアットマークとしました。気に入らなければリクエストの文字に変更します。
